### PR TITLE
[ejs] Fixing `Unexpected token : while compiling ejs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "commander": "^1.3.2",
         "mkdirp": "^0.3.5",
-        "ejs": "*"
+        "ejs": "~0.8.4"
     },
     "keywords": [
         "koa",


### PR DESCRIPTION
Locking `ejs` in version `~0.8.4` to fix:

![image](https://cloud.githubusercontent.com/assets/2034678/6436963/89a2b194-c096-11e4-914c-6e4e42ea19f6.png)
